### PR TITLE
New webtorrent interface; fix log parsing

### DIFF
--- a/webtorrent-hook.lua
+++ b/webtorrent-hook.lua
@@ -73,7 +73,7 @@ function play_torrent()
       mp.msg.info("Waiting for webtorrent server")
 
       local url_command = "tail -f " .. output_file
-         .. " | awk '/Server running at:/ {print $4; exit}'"
+         .. " | awk '/Server running at:/ {print $3; exit}' | sed 's#^at:##'"
       local url = os.capture(url_command, true)
       mp.msg.info("Webtorrent server is up")
 
@@ -90,7 +90,7 @@ function play_torrent()
       end
       open_videos[url] = {title=title,path=path,pid=pid}
 
-      mp.set_property("stream-open-filename", path)
+      mp.set_property("stream-open-filename", url)
 
       if settings.webtorrent_verbosity == "speed" then
          local printer_pid

--- a/webtorrent-hook.lua
+++ b/webtorrent-hook.lua
@@ -64,10 +64,11 @@ function play_torrent()
          .. "/webtorrent-output-" .. mp.get_time() .. ".log"
       -- --keep-seeding is to prevent webtorrent from quitting once the download
       -- is done
-      local webtorrent_command = "webtorrent "
+      local webtorrent_command = "webtorrent download '"
+         .. url .. "' "
          .. settings.webtorrent_flags
-         .. " --out '" .. settings.download_directory .. "' --keep-seeding '"
-         .. url .. "' &> " .. output_file .. " & echo $!"
+         .. " --out '" .. settings.download_directory .. "' --keep-seeding &> " 
+         .. output_file .. " & echo $!"
       local pid = os.capture(webtorrent_command)
       mp.msg.info("Waiting for webtorrent server")
 
@@ -89,7 +90,7 @@ function play_torrent()
       end
       open_videos[url] = {title=title,path=path,pid=pid}
 
-      mp.set_property("stream-open-filename", url)
+      mp.set_property("stream-open-filename", path)
 
       if settings.webtorrent_verbosity == "speed" then
          local printer_pid


### PR DESCRIPTION
Webtorrent changed its interface so I changed the command to  `webtorrent download` and moved `url` in front of it.

Also, It seems mpv wanted to open `url` and threw errors it couldn't find the file. I've changed that to `path` and it seems to work, although please review it carefully.

Fixes #7.