### PR TITLE
Fix markdown syntax for links

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,9 +18,9 @@ Peerflix is unmaintained, and webtorrent is supposedly significantly faster.
 Peerflix's output is not parseable, so the peerflix version of this script had to do a bunch of extra work with ~lsof~ to figure out the location of video files, the title of video files, and the process id of peerflix (in order to kill it). This script is a lot cleaner by comparison (though it could be better if webtorrent had a way to give [[https://github.com/webtorrent/webtorrent-cli/issues/132][more script-friendly output]]).
 
 * Disadvantages and Limitations
-Webtorrent has parseable output but is still not very script friendly. [[mpv-btfs-stream][https://github.com/noctuid/mpv-btfs-stream]] is cleaner and simpler by comparison and does not rely on parsing output. The advantage of webtorrent over btfs is that webtorrent is much faster. See [[here][https://github.com/noctuid/mpv-btfs-hook#comparison-with-mpv-webtorrent-hook]] for a full comparison.
+Webtorrent has parseable output but is still not very script friendly. [[https://github.com/noctuid/mpv-btfs-stream][mpv-btfs-stream]] is cleaner and simpler by comparison and does not rely on parsing output. The advantage of webtorrent over btfs is that webtorrent is much faster. See [[https://github.com/noctuid/mpv-btfs-hook#comparison-with-mpv-webtorrent-hook][here]] for a full comparison.
 
-Currently torrents that have multiple media files will not work correctly. Changes to webtorrent-cli are necessary to make this easily possible. If you need this functionality, you can use [[mpv-btfs-hook][https://github.com/noctuid/mpv-btfs-stream]] just for torrents that contain multiple videos or images.
+Currently torrents that have multiple media files will not work correctly. Changes to webtorrent-cli are necessary to make this easily possible. If you need this functionality, you can use [[https://github.com/noctuid/mpv-btfs-stream][mpv-btfs-stream]] just for torrents that contain multiple videos or images.
 
 See also [[https://github.com/mrxdst/webtorrent-mpv-hook][webtorrent-mpv-hook]] which directly uses the webtorrent library instead of webtorrent-cli. I am going to look at this plugin and will probably recommend using it in the future.
 


### PR DESCRIPTION
Syntax was reversed and was leading to missing pages.