### PR TITLE
Fix loadfile error

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -52,7 +52,7 @@ end
 
 function load_file_after_current(url, option_table, num_entries)
    mp.command_native({
-         "loadfile", url, "append", option_table
+         "loadfile", url, "append", -1, option_table
    })
    local index = mp.get_property("playlist-pos")
    mp.command_native({


### PR DESCRIPTION
Previously getting `Command loadfile: argument index has incompatible type.` After this change the script works as expected. Tested and working with mpv version 0.38.0. 