### PR TITLE
Fix for breaking changes in webtorrent-cli 5.1.X

### DIFF
--- a/webtorrent-wrap.sh
+++ b/webtorrent-wrap.sh
@@ -23,12 +23,24 @@ url=$(tail -f "$webtorrent_output_file" \
 		  | awk '/Server running at: ?/ {gsub(/Server running at: ?/, ""); print $1; exit}')
 
 base_url=$(echo "$url" | grep --extended-regexp --only-matching \
-							  'http://localhost:[0-9]+/')
-# print json of files
-xidel --silent --extract "//a/@href" "$base_url" |
-	jq --null-input --raw-input "
+							  'http://localhost:[0-9]+')
+webtorrent_hash=$(echo "$url" | grep --extended-regexp --only-matching \
+							  'webtorrent/[0-9a-f]+')
+
+# Get json of files
+webtorrent_results=$(xidel --silent --extract "//a/@href" "$base_url/$webtorrent_hash" |
+  jq --null-input --raw-input "
 {
     pid: $pid,
-    files: [inputs |  select(length>0)] | map({title: . | sub(\"[0-9]+/\"; \"\"), url: (\"$base_url\" + .)})
+    files: [inputs |  select(length>0)] | map({title: . | sub(\"/$webtorrent_hash/\"; \"\"), url: (\"$base_url\" + .)})
 }
-"
+")
+
+# Uncomment for debugging info
+# echo "$webtorrent_results" > ~/webtorrent-wrap.log
+# echo "URL             - $url" >> ~/webtorrent-wrap.log
+# echo "WEBTORRENT_HASH - $webtorrent_hash" >> ~/webtorrent-wrap.log
+# echo "BASE_URL        - $base_url" >> ~/webtorrent-wrap.log
+
+# Print results
+echo "$webtorrent_results"


### PR DESCRIPTION
`webtorrent-cli` version 5.1.X (maybe 5.0.X?) introduced changes to the http server which broke this script. These changes fix the error and introduce some additional debugging commands in `webtorrent-wrap.sh` that helped me fix the issue (lines 40-43).

Again, may want to hold off on pushing the changes since it's ~3 weeks since `webtorrent-cli` v5.0.0 was released.

Thanks.